### PR TITLE
Fix compilation errors

### DIFF
--- a/sqlitelib.h
+++ b/sqlitelib.h
@@ -251,7 +251,6 @@ class Statement {
   }
 
  private:
-  Statement(const Statement& rhs);
   Statement& operator=(const Statement& rhs);
 
   sqlite3_stmt* new_sqlite3_stmt(sqlite3* db, const char* query) {

--- a/sqlitelib.h
+++ b/sqlitelib.h
@@ -10,6 +10,7 @@
 
 #include <sqlite3.h>
 
+#include <memory>
 #include <string>
 #include <tuple>
 #include <type_traits>


### PR DESCRIPTION
@yhirose when trying to resolve the conflicts on #3 I discovered that `master` didn't build when using Visual Studio 16.9.4, so I opened this PR to fix the issues.